### PR TITLE
Start rate limiter immediately

### DIFF
--- a/src/Funccy/RateLimiter/RateLimiter.cs
+++ b/src/Funccy/RateLimiter/RateLimiter.cs
@@ -43,11 +43,13 @@ namespace Funccy
             {
                 await _time.WaitAsync(cancel);
 
+                var val = action();
+
                 await Task.Delay(_timeSpan);
 
                 _time.Release(1);
 
-                return action();
+                return val;
             }
             finally
             {

--- a/test/FunccyTests/RateLimiterTests.cs
+++ b/test/FunccyTests/RateLimiterTests.cs
@@ -27,17 +27,17 @@ namespace FunccyTests
             
             stopwatch.Stop();
 
-            Assert.IsTrue(results[0].IsNear(1000, 100));
-            Assert.IsTrue(results[1].IsNear(1000, 100));
-            Assert.IsTrue(results[2].IsNear(1000, 100));
+            Assert.IsTrue(results[0].IsNear(0, 100));
+            Assert.IsTrue(results[1].IsNear(0, 100));
+            Assert.IsTrue(results[2].IsNear(0, 100));
 
-            Assert.IsTrue(results[3].IsNear(2000, 100));
-            Assert.IsTrue(results[4].IsNear(2000, 100));
-            Assert.IsTrue(results[5].IsNear(2000, 100));
+            Assert.IsTrue(results[3].IsNear(1000, 100));
+            Assert.IsTrue(results[4].IsNear(1000, 100));
+            Assert.IsTrue(results[5].IsNear(1000, 100));
 
-            Assert.IsTrue(results[6].IsNear(3000, 100));
-            Assert.IsTrue(results[7].IsNear(3000, 100));
-            Assert.IsTrue(results[8].IsNear(3000, 100));
+            Assert.IsTrue(results[6].IsNear(2000, 100));
+            Assert.IsTrue(results[7].IsNear(2000, 100));
+            Assert.IsTrue(results[8].IsNear(2000, 100));
         }
     }
 }


### PR DESCRIPTION
Performs the action as soon as it enters the restricted zone and then delays, rather than waiting first and then doing the action